### PR TITLE
refresh PyPI version badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
     <img alt="Python 3.10+" src="https://img.shields.io/badge/Python-3.10%2B-3776AB?logo=python&amp;logoColor=white">
   </a>
   <a href="https://pypi.org/project/ppmat/">
-    <img alt="PyPI version" src="https://img.shields.io/pypi/v/ppmat?logo=pypi&amp;logoColor=white">
+    <img alt="PyPI version" src="https://img.shields.io/pypi/v/ppmat?logo=pypi&amp;logoColor=white&amp;cacheSeconds=300">
   </a>
   <a href="LICENSE">
     <img alt="Apache 2.0 License" src="https://img.shields.io/github/license/PaddlePaddle/PaddleMaterials">

--- a/README_PYPI.md
+++ b/README_PYPI.md
@@ -11,7 +11,7 @@
     <img alt="Python 3.10+" src="https://img.shields.io/badge/Python-3.10%2B-3776AB?logo=python&amp;logoColor=white">
   </a>
   <a href="https://pypi.org/project/ppmat/">
-    <img alt="PyPI version" src="https://img.shields.io/pypi/v/ppmat?logo=pypi&amp;logoColor=white">
+    <img alt="PyPI version" src="https://img.shields.io/pypi/v/ppmat?logo=pypi&amp;logoColor=white&amp;cacheSeconds=300">
   </a>
   <a href="https://github.com/PaddlePaddle/PaddleMaterials/blob/develop/LICENSE">
     <img alt="Apache 2.0 License" src="https://img.shields.io/github/license/PaddlePaddle/PaddleMaterials">

--- a/README_ja.md
+++ b/README_ja.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="Install.md"><img alt="Python 3.10+" src="https://img.shields.io/badge/Python-3.10%2B-3776AB?logo=python&amp;logoColor=white"></a>
-  <a href="https://pypi.org/project/ppmat/"><img alt="PyPI バージョン" src="https://img.shields.io/pypi/v/ppmat?logo=pypi&amp;logoColor=white"></a>
+  <a href="https://pypi.org/project/ppmat/"><img alt="PyPI バージョン" src="https://img.shields.io/pypi/v/ppmat?logo=pypi&amp;logoColor=white&amp;cacheSeconds=300"></a>
   <a href="LICENSE"><img alt="Apache 2.0 ライセンス" src="https://img.shields.io/github/license/PaddlePaddle/PaddleMaterials"></a>
   <a href="https://github.com/PaddlePaddle/PaddleMaterials/stargazers"><img alt="GitHub Stars" src="https://img.shields.io/github/stars/PaddlePaddle/PaddleMaterials?style=flat&amp;logo=github"></a>
 </p>

--- a/README_zh.md
+++ b/README_zh.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="Install.md"><img alt="Python 3.10+" src="https://img.shields.io/badge/Python-3.10%2B-3776AB?logo=python&amp;logoColor=white"></a>
-  <a href="https://pypi.org/project/ppmat/"><img alt="PyPI 版本" src="https://img.shields.io/pypi/v/ppmat?logo=pypi&amp;logoColor=white"></a>
+  <a href="https://pypi.org/project/ppmat/"><img alt="PyPI 版本" src="https://img.shields.io/pypi/v/ppmat?logo=pypi&amp;logoColor=white&amp;cacheSeconds=300"></a>
   <a href="LICENSE"><img alt="Apache 2.0 许可证" src="https://img.shields.io/github/license/PaddlePaddle/PaddleMaterials"></a>
   <a href="https://github.com/PaddlePaddle/PaddleMaterials/stargazers"><img alt="GitHub Stars" src="https://img.shields.io/github/stars/PaddlePaddle/PaddleMaterials?style=flat&amp;logo=github"></a>
 </p>


### PR DESCRIPTION
## Summary

- refresh the PyPI badge URL after publishing `ppmat 0.3.0`
- keep the English, Chinese, Japanese, and PyPI README variants consistent

## Verification

- PyPI reports `ppmat 0.3.0`
- the updated Shields URL renders `0.3.0`
- `git diff --check` passes